### PR TITLE
[internal] Bump Rails dependency version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,14 +28,14 @@ task :test => 'test:units'
 namespace :test do
   Rake::TestTask.new(:units) do |t|
     t.pattern = 'test/unit/**/*_test.rb'
-    t.ruby_opts << '-rubygems -w'
+    t.ruby_opts << '-rrubygems -w'
     t.libs << 'test'
     t.verbose = true
   end
 
   Rake::TestTask.new(:remote) do |t|
     t.pattern = 'test/remote/**/*_test.rb'
-    t.ruby_opts << '-rubygems -w'
+    t.ruby_opts << '-rrubygems -w'
     t.libs << 'test'
     t.verbose = true
   end

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 6.0')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 7.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
In order to upgrade Rails in the main Chargify app we need to bump the `activesupport` dependency version.