### PR TITLE
[bugfix] improve scrubing invalid byte sequence before parsing xml response from Windcave

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -310,7 +310,8 @@ module ActiveMerchant #:nodoc:
       def parse(xml_string)
         response = {}
 
-        xml = REXML::Document.new(xml_string.scrub)
+        utf8_xml_string = xml_string.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
+        xml = REXML::Document.new(utf8_xml_string)
 
         # Gather all root elements such as HelpText
         xml.elements.each('Txn/*') do |element|


### PR DESCRIPTION
Windcave responses sometimes include invalid UTF-8 bytes. It turns out that simple `.scrub` does not always work (most likely because it puts `�` as a replacement), so here we're applying `.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')` to make sure it scrubs invalid bytes properly