### PR TITLE
[bugfix] raise active merchant error when 500 error happens for eway

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_managed.rb
+++ b/lib/active_merchant/billing/gateways/eway_managed.rb
@@ -176,6 +176,10 @@ module ActiveMerchant #:nodoc:
                     raise StandardError, "Unexpected \"false\" in UpdateCustomerResult"
                   end
                 else
+                  if 'page cannot be displayed because an internal server error has occurred'.in?(body)
+                    raise ActiveMerchant::ConnectionError.new('Eway responded with server error', body)
+                  end
+
                   # ERROR: This state should never occur currently. We have handled
                   #        responses for all the methods which we support.
                   raise StandardError, "Unexpected response"


### PR DESCRIPTION
Why & what?
Eway gateway for 500 error was returning standard error so the sub was past due / canceled.
If we return the ActiveMerchant error, the sub will go in soft due. Do we want it? 🤷

related: https://github.com/maxio-com/chargify/pull/22437