### PR TITLE
[internal] Add level 3 data to Stripe

### DIFF
--- a/lib/active_merchant/billing/gateway.rb
+++ b/lib/active_merchant/billing/gateway.rb
@@ -275,9 +275,20 @@ module ActiveMerchant #:nodoc:
         money.respond_to?(:currency) ? money.currency : self.default_currency
       end
 
-      def truncate(value, max_size)
+      # Truncate string to given length
+      #
+      # @example
+      #
+      #   truncate("12345", 3)
+      #   => "1234"
+      #
+      # @param [String] value Text which needs to be truncated
+      # @param [String] index_of_last_char Index on which truncation need to be performed.
+      #
+      # @return [String] truncated string
+      def truncate(value, index_of_last_char)
         return nil unless value
-        value.to_s[0, max_size]
+        value.to_s[0, index_of_last_char]
       end
 
       def split_names(full_name)


### PR DESCRIPTION
Done: 
- Add required level 3 data to stripe

ToDo:
- Consider adding optional parameters if possible -  customer_reference, shipping_address_zip, shipping_from_zip, shipping_amount
- Make sure if all requirements for level 3 data are met:
<img width="893" alt="image" src="https://user-images.githubusercontent.com/10762340/235096124-1846bd5f-803d-4b8f-9857-f249bd04f8e5.png">

Side notes:
- changed param naming in truncate method instead of refactoring it to properly cut the length in all usages. Would be good to revisit it in future as current implementation can cause errors in current usages - from what I saw in usages it was probably cutting 1 character too much which might be above the limit of given gateway