### PR TITLE
[internal] bump square.rb gem from 6.3 to 7.0

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('square.rb', '~> 9.1')
+  s.add_dependency('square.rb', '~> 7.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('square.rb', '~> 6.3')
+  s.add_dependency('square.rb', '~> 7.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('square.rb', '~> 7.0')
+  s.add_dependency('square.rb', '~> 9.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')


### PR DESCRIPTION
#### Reference link
https://maxioevolution.atlassian.net/browse/PAYM-267

#### Why
`square.rb` gem in version prior to 7.0 is incompatible with Ruby 3.

#### What
`square.rb` gem has been bumped to version 7.0.