### PR TITLE
[internal] added exceptions  StripeCustomerManyPaymentMethodWithoutDefault and StripeCustomerDoesNotExist

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -397,8 +397,7 @@ module ActiveMerchant #:nodoc:
         return default_source if default_source
 
         if payment_methods.count > 1
-          raise "Customer has more than one payment method but doesn't have default one."
-          #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
+          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 
@@ -407,8 +406,7 @@ module ActiveMerchant #:nodoc:
         return payment_methods.default_payment_method if payment_methods.default_payment_method
 
         if payment_methods.count > 1
-          raise "Customer has more than one payment method but doesn't have default one."
-          #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
+          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -2,6 +2,9 @@ require 'active_support/core_ext/hash/slice'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
+    class StripeCustomerManyPaymentMethodWithoutDefault < StandardError; end
+    class StripeCustomerDoesNotExist < StandardError; end
+
     class StripeGateway < Gateway
       self.live_url = 'https://api.stripe.com/v1/'
 
@@ -394,7 +397,7 @@ module ActiveMerchant #:nodoc:
         return default_source if default_source
 
         if payment_methods.count > 1
-          raise "Customer has more than one payment method but doesn't have default one."
+          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 
@@ -403,13 +406,13 @@ module ActiveMerchant #:nodoc:
         return payment_methods.default_payment_method if payment_methods.default_payment_method
 
         if payment_methods.count > 1
-          raise "Customer has more than one payment method but doesn't have default one."
+          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 
       def customer_payment_methods(customer, payment_type)
         r = commit(:get, "payment_methods?customer=#{customer}&type=#{payment_type}", nil, options)
-        raise r.message unless r.success?
+        raise StripeCustomerDoesNotExist, r.message unless r.success?
 
         payment_methods = r.params["data"]
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -397,7 +397,8 @@ module ActiveMerchant #:nodoc:
         return default_source if default_source
 
         if payment_methods.count > 1
-          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
+          raise RuntimeError.new
+          #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 
@@ -406,7 +407,8 @@ module ActiveMerchant #:nodoc:
         return payment_methods.default_payment_method if payment_methods.default_payment_method
 
         if payment_methods.count > 1
-          raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
+          raise RuntimeError.new
+          #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -397,7 +397,7 @@ module ActiveMerchant #:nodoc:
         return default_source if default_source
 
         if payment_methods.count > 1
-          raise RuntimeError.new
+          raise "Customer has more than one payment method but doesn't have default one."
           #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end
@@ -407,7 +407,7 @@ module ActiveMerchant #:nodoc:
         return payment_methods.default_payment_method if payment_methods.default_payment_method
 
         if payment_methods.count > 1
-          raise RuntimeError.new
+          raise "Customer has more than one payment method but doesn't have default one."
           #raise StripeCustomerManyPaymentMethodWithoutDefault, "Customer has more than one payment method but doesn't have default one."
         end
       end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -2,8 +2,8 @@ require 'active_support/core_ext/hash/slice'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
-    class StripeCustomerManyPaymentMethodWithoutDefault < StandardError; end
-    class StripeCustomerDoesNotExist < StandardError; end
+    class StripeCustomerManyPaymentMethodWithoutDefault < RuntimeError; end
+    class StripeCustomerDoesNotExist < RuntimeError; end
 
     class StripeGateway < Gateway
       self.live_url = 'https://api.stripe.com/v1/'


### PR DESCRIPTION
**What:** 

- added 2 new Exceptions to StripeGateway
- changed to RunTimeError instead of StandardError, because there is some problem with conduit gem

This PR is related with:
https://github.com/maxio-com/chargify/pull/21872

And Jira Task:
https://chargify.atlassian.net/jira/software/c/projects/BQ/boards/86?modal=detail&selectedIssue=BQ-991&assignee=62d8043596f239ca6ae81ede

