### PR TITLE
[bugfix] update windcave domain

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -18,11 +18,11 @@ module ActiveMerchant #:nodoc:
 
       self.supported_countries = %w[ AU CA DE ES FR GB HK IE MY NL NZ SG US ZA ]
 
-      self.homepage_url = 'http://www.paymentexpress.com/'
-      self.display_name = 'PaymentExpress'
+      self.homepage_url = 'https://www.windcave.com/'
+      self.display_name = 'Windcave (formerly PaymentExpress)'
 
-      self.live_url = 'https://sec.paymentexpress.com/pxpost.aspx'
-      self.test_url = 'https://uat.paymentexpress.com/pxpost.aspx'
+      self.live_url = 'https://sec.windcave.com/pxpost.aspx'
+      self.test_url = 'https://uat.windcave.com/pxpost.aspx'
 
       APPROVED = '1'
 


### PR DESCRIPTION
Ticket: [PAYM-616](https://maxioevolution.atlassian.net/browse/PAYM-616)

### WHAT?
Update windcave test and live urls

### WHY?
Since the end of June our [external specs](https://buildkite.com/chargify-ci/chargify-main-app/builds/95309#_) for windcave started to fail due to the missing domain - `connection to the remote server could not be established`

```
$ nslookup uat.paymentexpress.com
Server:		2001:730:3ed2:1000::53
Address:	2001:730:3ed2:1000::53#53

** server can't find uat.paymentexpress.com: NXDOMAIN
```

It appears that Windcave updated their UAT domain on June 28, 2023, causing merchants using our integration with Windcave on their test sites to encounter transaction failures starting on that date. 

Windcave provided PDF to their merchants notifying them about IP addresses change in case of any merchant want to whitelist them. 
In PDF there are mentioned dates when this change is going to be rolled out for test and live env:
```
Timeline

Changes will start to be rolled out from the following dates.

Production: 15th August 2023

UAT: 28th June 2023 

```

This date matches the date when we started to notice failures with our external windcave specs. Although pdf doesn't mention domain change, on their site there is a note that windcave domain should be used instead of paymentexpress one - https://www.windcave.com/connectivity-about
<img width="1216" alt="image" src="https://github.com/maxio-com/active_merchant/assets/10762340/75d63ac3-34b3-4208-831b-055e1c43cc18">

New windcave test url:

```
nslookup uat.windcave.com
Server:		2001:730:3ed2:1000::53
Address:	2001:730:3ed2:1000::53#53

Non-authoritative answer:
uat.windcave.com	canonical name = uat.windcave.com.cdn.cloudflare.net.
Name:	uat.windcave.com.cdn.cloudflare.net
Address: 172.64.145.150
Name:	uat.windcave.com.cdn.cloudflare.net
Address: 104.18.42.106
```

And the `nslookup` for production domains:
```
$ nslookup sec.paymentexpress.com
Server:		2001:730:3ed2:1000::53
Address:	2001:730:3ed2:1000::53#53

Non-authoritative answer:
Name:	sec.paymentexpress.com
Address: 45.75.195.9

$ nslookup sec.windcave.com
Server:		2001:730:3ed2:1000::53
Address:	2001:730:3ed2:1000::53#53

Non-authoritative answer:
Name:	sec.windcave.com
Address: 45.75.195.9
```
It is visible that both domains resolves with same IP address.

[PAYM-616]: https://maxioevolution.atlassian.net/browse/PAYM-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ