### PR TITLE
[bugfix] Include 3ds info for store action

### DIFF
--- a/lib/active_merchant/billing/gateways/blue_snap.rb
+++ b/lib/active_merchant/billing/gateways/blue_snap.rb
@@ -141,6 +141,7 @@ module ActiveMerchant
               doc.send('payment-sources') do
                 payment_method_details.check? ? store_echeck(doc, payment_method) : store_credit_card(doc, payment_method)
               end
+              add_3ds(doc, options[:three_d_secure])
               add_order(doc, options)
             end
           end


### PR DESCRIPTION
### What?
Include 3ds ref info for store action

### Why?
For UK it is mandatory to include such info in store action, banks may reject request otherwise

### Tests
<img width="985" alt="image" src="https://github.com/maxio-com/active_merchant/assets/10762340/f328600f-6a50-46ea-adaa-3bc69f12aa36">

### Related PRs:
https://github.com/maxio-com/chargify/pull/23163

Ticket: [PAYM-553](https://maxioevolution.atlassian.net/browse/PAYM-553)

[PAYM-553]: https://maxioevolution.atlassian.net/browse/PAYM-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ