### PR TITLE
[feature] Add fraudnet header if correlation_id present

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -236,6 +236,9 @@ module ActiveMerchant #:nodoc:
           )
         }.tap do |h|
           h['PayPal-Request-Id'] = options[:order_id] if options[:order_id]
+          if options[:device_data] && options[:device_data][:correlation_id]
+            h['PAYPAL-CLIENT-METADATA-ID'] = options[:device_data][:correlation_id]
+          end
         end
       end
     end


### PR DESCRIPTION
Ticket: [PAYM-777](https://maxioevolution.atlassian.net/browse/PAYM-777)

### What?

Add fraudnet header when `correlation_id` is being passed

### Why?
To have additional fraud protection on paypal layer


[PAYM-777]: https://maxioevolution.atlassian.net/browse/PAYM-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ