### PR TITLE
[feature] Add experience context to orders api call

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -106,7 +106,18 @@ module ActiveMerchant #:nodoc:
         post[:payment_source] ||= {}
         payment_source = options[:payment_type] == "paypal_account" ? :paypal : :card
         post[:payment_source][payment_source] = {
-          vault_id: vault_id
+          vault_id: vault_id,
+          experience_context: {
+            payment_method_preference: "IMMEDIATE_PAYMENT_REQUIRED",
+            brand_name: "Maxio",
+            locale: "en-US",
+            landing_page: "LOGIN",
+            shipping_preference: physical_retail?(options) ? "SET_PROVIDED_ADDRESS" : "NO_SHIPPING",
+            user_action: "PAY_NOW",
+            # Placeholder values
+            return_url: "https://example.com/returnUrl",
+            cancel_url: "https://example.com/cancelUrl"
+          }
         }
       end
 

--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -169,7 +169,7 @@ module ActiveMerchant #:nodoc:
       def price_object(price_in_cent, currency)
         {
           currency_code: currency,
-          value: amount(price_in_cent)
+          value: amount(price_in_cent || 0)
         }
       end
 


### PR DESCRIPTION
### WHAT?
Include experiance context in order api call

### WHY?
To serve better experience for buyers through PayPal gateway

Ticket: [PAYM-1033](https://maxioevolution.atlassian.net/browse/PAYM-1033)

[PAYM-1033]: https://maxioevolution.atlassian.net/browse/PAYM-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ