### PR TITLE
add sca info when using credit card for paypal rtau

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -281,11 +281,6 @@ module ActiveMerchant #:nodoc:
         raw_response = raw_ssl_request(http_method, url, body, headers(options))
         http_code = raw_response.code.to_i
         response = JSON.parse(handle_response(raw_response))
-        puts "*@" * 100
-        puts body
-        puts "*@" * 100
-        puts response.inspect
-        puts "*@" * 100
         success = success_from(http_method, path, http_code, response)
 
         Response.new(

--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -281,6 +281,11 @@ module ActiveMerchant #:nodoc:
         raw_response = raw_ssl_request(http_method, url, body, headers(options))
         http_code = raw_response.code.to_i
         response = JSON.parse(handle_response(raw_response))
+        puts "*@" * 100
+        puts body
+        puts "*@" * 100
+        puts response.inspect
+        puts "*@" * 100
         success = success_from(http_method, path, http_code, response)
 
         Response.new(


### PR DESCRIPTION
## This PR solves [PAYM-1558](https://maxioevolution.atlassian.net/browse/PAYM-1558)
- It adds the SCA indicators for triggering Paypal's RTAU

[PAYM-1558]: https://maxioevolution.atlassian.net/browse/PAYM-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ