### PR TITLE
[internal] Bump square gem to have access to card API

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")
-  s.add_dependency('square.rb', '~> 7.0')
+  s.add_dependency('square.rb', '~> 16.0')
   s.add_dependency('jwt')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
Ticket: https://maxioevolution.atlassian.net/browse/PAYM-1881

### WHAT?
Bump square gem version

### WHY?
To have access to Cards API and card resource in current responses