### PR TITLE
[bugfix] Check against capture status in PPCP purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -312,7 +312,12 @@ module ActiveMerchant #:nodoc:
         elsif path.start_with?('/v3/vault/payment-tokens')
           true
         elsif path.start_with?('/v2/checkout/orders')
-          response['status'] == 'COMPLETED'
+          response['status'] == 'COMPLETED' &&
+            response['purchase_units'].all? do |unit|
+              unit['payments']['captures'].all? do |capture|
+                capture['status'] == 'COMPLETED'
+              end
+            end
         elsif path.start_with?('/v2/payments/captures')
           response['status'] == 'COMPLETED'
         end

--- a/test/unit/gateways/pay_pal_complete_test.rb
+++ b/test/unit/gateways/pay_pal_complete_test.rb
@@ -24,6 +24,14 @@ class PayPalCompleteTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_unsuccessful_purchase
+    stub_auth
+    stub_failed_capture
+
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
   def test_successful_store
     stub_auth
     stub_card_vaulting
@@ -111,6 +119,12 @@ class PayPalCompleteTest < Test::Unit::TestCase
     @gateway.expects(:raw_ssl_request).with do |http_method, endpoint|
       http_method == :delete && endpoint.to_s.start_with?('https://api-m.sandbox.paypal.com/v3/vault/payment-tokens')
     end.returns(stubbed_response_for(:successful_unstore_response, code: 204))
+  end
+
+  def stub_failed_capture
+    @gateway.expects(:raw_ssl_request).with do |_, endpoint|
+      endpoint.to_s.start_with?('https://api-m.sandbox.paypal.com/v2/checkout/orders')
+    end.returns(stubbed_response_for(:successful_create_order_response_with_failed_capture, code: 201))
   end
 
   def successful_access_token_response
@@ -281,6 +295,82 @@ class PayPalCompleteTest < Test::Unit::TestCase
                     "avs_code": "A",
                     "cvv_code": "M",
                     "response_code": "0000"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "links": [
+          { "href": "https://api.sandbox.paypal.com/v2/checkout/orders/8UY678134N833721C",
+            "rel": "self",
+            "method": "GET"
+          }
+        ]
+      }
+    RESPONSE
+  end
+
+  def successful_create_order_response_with_failed_capture
+    <<~RESPONSE
+      {
+        "id": "8UY678134N833721C",
+        "status": "COMPLETED",
+        "payment_source": {
+          "card": {
+            "name": "Lavern Hane",
+            "last_digits": "1111",
+            "expiry": "2030-03",
+            "brand": "VISA",
+            "available_networks": ["VISA"],
+            "type": "UNKNOWN",
+            "bin_details": {}
+          }
+        },
+        "purchase_units": [
+          {
+            "reference_id": "hal-2023121103493138",
+            "payments": {
+              "captures": [
+                {
+                  "id": "9T984786YR7857502",
+                  "status": "DECLINED",
+                  "amount": {
+                    "currency_code": "USD", "value": "375.00"
+                  },
+                  "final_capture": true,
+                  "disbursement_mode": "INSTANT",
+                  "seller_protection": {
+                    "status": "NOT_ELIGIBLE"
+                  },
+                  "seller_receivable_breakdown": {
+                    "gross_amount": {
+                      "currency_code": "USD", "value": "375.00"
+                    }, "paypal_fee": {
+                      "currency_code": "USD", "value": "10.20"
+                    }, "net_amount": {
+                      "currency_code": "USD", "value": "364.80"
+                    }
+                  },
+                  "links": [
+                    {
+                      "href": "https://api.paypal.com/v2/payments/captures/9T984786YR7857502",
+                      "rel": "self",
+                      "method": "GET"
+                    },
+                    {
+                      "href": "https://api.paypal.com/v2/checkout/orders/2R602439FG987541K",
+                      "rel": "up",
+                      "method": "GET"
+                    }
+                  ],
+                  "create_time": "2024-10-28T15:46:13Z",
+                  "update_time": "2024-10-28T15:46:13Z",
+                  "network_transaction_reference": {
+                    "id": "009116868994323", "network": "AMEX"
+                  },
+                  "processor_response": {
+                    "avs_code": "Y", "response_code": "5100"
                   }
                 }
               ]

--- a/test/unit/gateways/pay_pal_complete_test.rb
+++ b/test/unit/gateways/pay_pal_complete_test.rb
@@ -11,7 +11,8 @@ class PayPalCompleteTest < Test::Unit::TestCase
     @options = {
       order_id: '1',
       billing_address: address,
-      description: 'Store Purchase'
+      description: 'Store Purchase',
+      line_items: []
     }
   end
 


### PR DESCRIPTION
Ticket: https://maxioevolution.atlassian.net/browse/PAYM-1934

### WHAT?
Check against capture status in PPCP purchase

### WHY?
It is possible that order request will return positive status but capture nested inside has failure. That leads to false positive purchases on AB side.

### TESTS
<img width="851" alt="image" src="https://github.com/user-attachments/assets/0493e574-52b5-4bcd-a516-9e3ed2985a73">
