### PR TITLE
[bugfix] Raise error only upon 5xx HTTP statuses

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_complete.rb
+++ b/lib/active_merchant/billing/gateways/paypal_complete.rb
@@ -340,7 +340,7 @@ module ActiveMerchant #:nodoc:
 
       def handle_response(response)
         case response.code.to_i
-        when 200..300
+        when 200..499
           response.body || '{}'
         else
           raise ResponseError.new(response)


### PR DESCRIPTION
Ticket: https://maxioevolution.atlassian.net/browse/PAYM-1986

### WHAT?
Raise error only upon 5xx HTTP statuses

### WHY?
As for 4xx follow common structure where we can parse out valueable info