### PR TITLE
[feature] Paym 1989 gateway cybersource soap api authentication update

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -1,5 +1,5 @@
-module ActiveMerchant #:nodoc:
-  module Billing #:nodoc:
+module ActiveMerchant # :nodoc:
+  module Billing # :nodoc:
     # Initial setup instructions can be found in
     # http://cybersource.com/support_center/implementation/downloads/soap_api/SOAP_toolkits.pdf
     #
@@ -24,69 +24,75 @@ module ActiveMerchant #:nodoc:
       self.test_url = 'https://ics2wstesta.ic3.com/commerce/1.x/transactionProcessor'
       self.live_url = 'https://ics2wsa.ic3.com/commerce/1.x/transactionProcessor'
 
-      XSD_VERSION = '1.153'
+      XSD_VERSION = '1.153'.freeze
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :dankort, :maestro]
-      self.supported_countries = %w(US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB ZA)
+      # Constants for p12 cert auth
+      WSU_NS = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'.freeze
+      WSSE_NS = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'.freeze
+      SOAP_NS = 'http://schemas.xmlsoap.org/soap/envelope/'.freeze
+      DS_NS = 'http://www.w3.org/2000/09/xmldsig#'.freeze
+
+      self.supported_cardtypes = %i[visa master american_express discover diners_club jcb dankort maestro]
+      self.supported_countries = %w[US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB ZA]
 
       self.default_currency = 'USD'
-      self.currencies_without_fractions = %w(JPY)
+      self.currencies_without_fractions = %w[JPY]
 
       self.homepage_url = 'http://www.cybersource.com'
       self.display_name = 'CyberSource'
 
       @@credit_card_codes = {
-        :visa  => '001',
-        :master => '002',
-        :american_express => '003',
-        :discover => '004',
-        :diners_club => '005',
-        :jcb => '007',
-        :dankort => '034',
-        :maestro => '042'
+        visa: '001',
+        master: '002',
+        american_express: '003',
+        discover: '004',
+        diners_club: '005',
+        jcb: '007',
+        dankort: '034',
+        maestro: '042'
       }
 
       @@response_codes = {
-        :r100 => 'Successful transaction',
-        :r101 => 'Request is missing one or more required fields',
-        :r102 => 'One or more fields contains invalid data',
-        :r150 => 'General failure',
-        :r151 => 'The request was received but a server time-out occurred',
-        :r152 => 'The request was received, but a service timed out',
-        :r200 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
-        :r201 => 'The issuing bank has questions about the request',
-        :r202 => 'Expired card',
-        :r203 => 'General decline of the card',
-        :r204 => 'Insufficient funds in the account',
-        :r205 => 'Stolen or lost card',
-        :r207 => 'Issuing bank unavailable',
-        :r208 => 'Inactive card or card not authorized for card-not-present transactions',
-        :r209 => 'American Express Card Identifiction Digits (CID) did not match',
-        :r210 => 'The card has reached the credit limit',
-        :r211 => 'Invalid card verification number',
-        :r221 => "The customer matched an entry on the processor's negative file",
-        :r230 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
-        :r231 => 'Invalid account number',
-        :r232 => 'The card type is not accepted by the payment processor',
-        :r233 => 'General decline by the processor',
-        :r234 => 'A problem exists with your CyberSource merchant configuration',
-        :r235 => 'The requested amount exceeds the originally authorized amount',
-        :r236 => 'Processor failure',
-        :r237 => 'The authorization has already been reversed',
-        :r238 => 'The authorization has already been captured',
-        :r239 => 'The requested transaction amount must match the previous transaction amount',
-        :r240 => 'The card type sent is invalid or does not correlate with the credit card number',
-        :r241 => 'The request ID is invalid',
-        :r242 => 'You requested a capture, but there is no corresponding, unused authorization record.',
-        :r243 => 'The transaction has already been settled or reversed',
-        :r244 => 'The bank account number failed the validation check',
-        :r246 => 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
-        :r247 => 'You requested a credit for a capture that was previously voided',
-        :r250 => 'The request was received, but a time-out occurred with the payment processor',
-        :r254 => 'Your CyberSource account is prohibited from processing stand-alone refunds',
-        :r255 => 'Your CyberSource account is not configured to process the service in the country you specified',
-        :r475 => 'The customer is enrolled in payer authentication. Authenticate the cardholder before continuing with the transaction.',
-        :r476 => 'The customer cannot be authenticated'
+        r100: 'Successful transaction',
+        r101: 'Request is missing one or more required fields',
+        r102: 'One or more fields contains invalid data',
+        r150: 'General failure',
+        r151: 'The request was received but a server time-out occurred',
+        r152: 'The request was received, but a service timed out',
+        r200: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
+        r201: 'The issuing bank has questions about the request',
+        r202: 'Expired card',
+        r203: 'General decline of the card',
+        r204: 'Insufficient funds in the account',
+        r205: 'Stolen or lost card',
+        r207: 'Issuing bank unavailable',
+        r208: 'Inactive card or card not authorized for card-not-present transactions',
+        r209: 'American Express Card Identifiction Digits (CID) did not match',
+        r210: 'The card has reached the credit limit',
+        r211: 'Invalid card verification number',
+        r221: "The customer matched an entry on the processor's negative file",
+        r230: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
+        r231: 'Invalid account number',
+        r232: 'The card type is not accepted by the payment processor',
+        r233: 'General decline by the processor',
+        r234: 'A problem exists with your CyberSource merchant configuration',
+        r235: 'The requested amount exceeds the originally authorized amount',
+        r236: 'Processor failure',
+        r237: 'The authorization has already been reversed',
+        r238: 'The authorization has already been captured',
+        r239: 'The requested transaction amount must match the previous transaction amount',
+        r240: 'The card type sent is invalid or does not correlate with the credit card number',
+        r241: 'The request ID is invalid',
+        r242: 'You requested a capture, but there is no corresponding, unused authorization record.',
+        r243: 'The transaction has already been settled or reversed',
+        r244: 'The bank account number failed the validation check',
+        r246: 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
+        r247: 'You requested a credit for a capture that was previously voided',
+        r250: 'The request was received, but a time-out occurred with the payment processor',
+        r254: 'Your CyberSource account is prohibited from processing stand-alone refunds',
+        r255: 'Your CyberSource account is not configured to process the service in the country you specified',
+        r475: 'The customer is enrolled in payer authentication. Authenticate the cardholder before continuing with the transaction.',
+        r476: 'The customer cannot be authenticated'
       }
 
       # These are the options that can be used when creating a new CyberSource
@@ -204,7 +210,7 @@ module ActiveMerchant #:nodoc:
       # This functionality is only supported by this particular gateway may
       # be changed at any time
       def calculate_tax(creditcard, options)
-        requires!(options,  :line_items)
+        requires!(options, :line_items)
         setup_address_hash(options)
         commit(build_tax_calculation_request(creditcard, options), :calculate_tax, nil, options)
       end
@@ -220,13 +226,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def scrub(transcript)
-        transcript.
-          gsub(%r((<wsse:Password [^>]*>)[^<]*(</wsse:Password>))i, '\1[FILTERED]\2').
-          gsub(%r((<accountNumber>)[^<]*(</accountNumber>))i, '\1[FILTERED]\2').
-          gsub(%r((<cvNumber>)[^<]*(</cvNumber>))i, '\1[FILTERED]\2').
-          gsub(%r((<cavv>)[^<]*(</cavv>))i, '\1[FILTERED]\2').
-          gsub(%r((<xid>)[^<]*(</xid>))i, '\1[FILTERED]\2').
-          gsub(%r((<authenticationData>)[^<]*(</authenticationData>))i, '\1[FILTERED]\2')
+        transcript
+          .gsub(%r{(<wsse:Password [^>]*>)[^<]*(</wsse:Password>)}i, '\1[FILTERED]\2')
+          .gsub(%r{(<accountNumber>)[^<]*(</accountNumber>)}i, '\1[FILTERED]\2')
+          .gsub(%r{(<cvNumber>)[^<]*(</cvNumber>)}i, '\1[FILTERED]\2')
+          .gsub(%r{(<cavv>)[^<]*(</cavv>)}i, '\1[FILTERED]\2')
+          .gsub(%r{(<xid>)[^<]*(</xid>)}i, '\1[FILTERED]\2')
+          .gsub(%r{(<authenticationData>)[^<]*(</authenticationData>)}i, '\1[FILTERED]\2')
       end
 
       def supports_network_tokenization?
@@ -244,18 +250,18 @@ module ActiveMerchant #:nodoc:
       # were only provided with one or two of them or even none
       def setup_address_hash(options)
         default_address = {
-          :address1 => 'Unspecified',
-          :city => 'Unspecified',
-          :state => 'NC',
-          :zip => '00000',
-          :country => 'US'
+          address1: 'Unspecified',
+          city: 'Unspecified',
+          state: 'NC',
+          zip: '00000',
+          country: 'US'
         }
         options[:billing_address] = options[:billing_address] || options[:address] || default_address
         options[:shipping_address] = options[:shipping_address] || {}
       end
 
       def build_auth_request(money, creditcard_or_reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -269,7 +275,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_tax_calculation_request(creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, creditcard, options[:billing_address], options, false)
         add_address(xml, creditcard, options[:shipping_address], options, true)
         add_line_item_data(xml, options)
@@ -283,7 +289,7 @@ module ActiveMerchant #:nodoc:
         order_id, request_id, request_token = authorization.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_purchase_data(xml, money, true, options)
         add_capture_service(xml, request_id, request_token)
         add_business_rules_data(xml, authorization, options)
@@ -291,7 +297,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_purchase_request(money, payment_method_or_reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -309,14 +315,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_void_request(identification, options)
-        order_id, request_id, request_token, action, money, currency  = identification.split(';')
+        order_id, request_id, request_token, action, money, currency = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         if action == 'capture'
           add_void_service(xml, request_id, request_token)
         else
-          add_purchase_data(xml, money.to_i, true, options.merge(:currency => currency || default_currency))
+          add_purchase_data(xml, money.to_i, true, options.merge(currency: currency || default_currency))
           add_auth_reversal_service(xml, request_id, request_token)
         end
         xml.target!
@@ -326,7 +332,7 @@ module ActiveMerchant #:nodoc:
         order_id, request_id, request_token = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_purchase_data(xml, money, true, options)
         add_credit_service(xml, request_id, request_token)
 
@@ -334,7 +340,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_credit_request(money, reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
 
         add_purchase_data(xml, money, true, options)
         add_subscription(xml, options, reference)
@@ -344,12 +350,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_create_subscription_request(payment_method, options)
-        default_subscription_params = {:frequency => 'on-demand', :amount => 0, :automatic_renew => false}
+        default_subscription_params = { frequency: 'on-demand', amount: 0, automatic_renew: false }
         options[:subscription] = default_subscription_params.update(
           options[:subscription] || {}
         )
 
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
         if card_brand(payment_method) == 'check'
@@ -374,7 +380,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_update_subscription_request(reference, creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_address(xml, creditcard, options[:billing_address], options) unless options[:billing_address].blank?
         add_purchase_data(xml, options[:setup_fee], true, options) unless options[:setup_fee].blank?
         add_creditcard(xml, creditcard)    if creditcard
@@ -386,21 +392,21 @@ module ActiveMerchant #:nodoc:
       end
 
       def build_delete_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_subscription(xml, options, reference)
         add_subscription_delete_service(xml, options)
         xml.target!
       end
 
       def build_retrieve_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         add_subscription(xml, options, reference)
         add_subscription_retrieve_service(xml, options)
         xml.target!
       end
 
-      def build_validate_pinless_debit_request(creditcard, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+      def build_validate_pinless_debit_request(creditcard, _options)
+        xml = Builder::XmlMarkup.new indent: 2
         add_creditcard(xml, creditcard)
         add_validate_pinless_debit_service(xml)
         xml.target!
@@ -409,24 +415,24 @@ module ActiveMerchant #:nodoc:
       def add_business_rules_data(xml, payment_method, options)
         prioritized_options = [options, @options]
 
-        unless network_tokenization?(payment_method)
-          xml.tag! 'businessRules' do
-            xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
-            xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)
-          end
+        return if network_tokenization?(payment_method)
+
+        xml.tag! 'businessRules' do
+          xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
+          xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)
         end
       end
 
       def extract_option(prioritized_options, option_name)
         options_matching_key = prioritized_options.detect do |options|
-          options.has_key? option_name
+          options.key? option_name
         end
         options_matching_key[option_name] if options_matching_key
       end
 
       def add_line_item_data(xml, options)
         options[:line_items].each_with_index do |value, index|
-          xml.tag! 'item', {'id' => index} do
+          xml.tag! 'item', { 'id' => index } do
             xml.tag! 'unitPrice', localized_amount(value[:declared_value].to_i, options[:currency] || default_currency)
             xml.tag! 'quantity', value[:quantity]
             xml.tag! 'productCode', value[:code] || 'shipping_only'
@@ -440,7 +446,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'merchantID', @options[:login]
         xml.tag! 'merchantReferenceCode', options[:order_id] || generate_unique_id
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
-        xml.tag! 'clientLibraryVersion',  VERSION
+        xml.tag! 'clientLibraryVersion', VERSION
         xml.tag! 'clientEnvironment', RUBY_PLATFORM
         add_merchant_descriptor(xml, options)
       end
@@ -453,10 +459,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def add_purchase_data(xml, money = 0, include_grand_total = false, options={})
+      def add_purchase_data(xml, money = 0, include_grand_total = false, options = {})
         xml.tag! 'purchaseTotals' do
           xml.tag! 'currency', options[:currency] || currency(money)
-          xml.tag!('grandTotalAmount', localized_amount(money, options[:currency] || default_currency))  if include_grand_total
+          if include_grand_total
+            xml.tag!('grandTotalAmount',
+                     localized_amount(money, options[:currency] || default_currency))
+          end
         end
       end
 
@@ -474,9 +483,15 @@ module ActiveMerchant #:nodoc:
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
           xml.tag! 'phoneNumber',           address[:phone]                   unless address[:phone].blank?
           xml.tag! 'email',                 options[:email] || 'null@cybersource.com'
-          xml.tag! 'ipAddress',             options[:ip]                      unless options[:ip].blank? || shipTo
-          xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
-          xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?
+          xml.tag! 'ipAddress',             options[:ip] unless options[:ip].blank? || shipTo
+          unless options[:drivers_license_number].blank?
+            xml.tag! 'driversLicenseNumber',
+                     options[:drivers_license_number]
+          end
+          unless options[:drivers_license_state].blank?
+            xml.tag! 'driversLicenseState',
+                     options[:drivers_license_state]
+          end
         end
       end
 
@@ -493,7 +508,10 @@ module ActiveMerchant #:nodoc:
           xml.tag!('accountNumber', creditcard.number) unless creditcard.number.blank?
           xml.tag! 'expirationMonth', format(creditcard.month, :two_digits)
           xml.tag! 'expirationYear', format(creditcard.year, :four_digits)
-          xml.tag!('cvNumber', creditcard.verification_value) unless @options[:ignore_cvv] || creditcard.verification_value.blank?
+          unless @options[:ignore_cvv] || creditcard.verification_value.blank?
+            xml.tag!('cvNumber',
+                     creditcard.verification_value)
+          end
           xml.tag! 'cardType', @@credit_card_codes[card_brand(creditcard).to_sym]
         end
       end
@@ -527,7 +545,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_tax_service(xml)
-        xml.tag! 'taxService', {'run' => 'true'} do
+        xml.tag! 'taxService', { 'run' => 'true' } do
           xml.tag!('nexus', @options[:nexus]) unless @options[:nexus].blank?
           xml.tag!('sellerRegistration', @options[:vat_reg_number]) unless @options[:vat_reg_number].blank?
         end
@@ -537,7 +555,7 @@ module ActiveMerchant #:nodoc:
         if network_tokenization?(payment_method)
           add_auth_network_tokenization(xml, payment_method, options)
         else
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             check_for_stored_cred_commerce_indicator(xml, options)
           end
         end
@@ -545,13 +563,15 @@ module ActiveMerchant #:nodoc:
 
       def check_for_stored_cred_commerce_indicator(xml, options)
         return unless options[:stored_credential]
-        if commerce_indicator(options)
-          xml.tag!('commerceIndicator', commerce_indicator(options))
-        end
+
+        return unless commerce_indicator(options)
+
+        xml.tag!('commerceIndicator', commerce_indicator(options))
       end
 
       def commerce_indicator(options)
         return if options[:stored_credential][:initial_transaction]
+
         case options[:stored_credential][:reason_type]
         when 'installment' then 'install'
         when 'recurring' then 'recurring'
@@ -562,12 +582,12 @@ module ActiveMerchant #:nodoc:
         payment_method.is_a?(NetworkTokenizationCreditCard)
       end
 
-      def add_auth_network_tokenization(xml, payment_method, options)
+      def add_auth_network_tokenization(xml, payment_method, _options)
         return unless network_tokenization?(payment_method)
 
         case card_brand(payment_method).to_sym
         when :visa
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('cavv', payment_method.payment_cryptogram)
             xml.tag!('commerceIndicator', 'vbv')
             xml.tag!('xid', payment_method.payment_cryptogram)
@@ -577,12 +597,12 @@ module ActiveMerchant #:nodoc:
             xml.tag!('authenticationData', payment_method.payment_cryptogram)
             xml.tag!('collectionIndicator', '2')
           end
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('commerceIndicator', 'spa')
           end
         when :american_express
           cryptogram = Base64.decode64(payment_method.payment_cryptogram)
-          xml.tag! 'ccAuthService', {'run' => 'true'} do
+          xml.tag! 'ccAuthService', { 'run' => 'true' } do
             xml.tag!('cavv', Base64.encode64(cryptogram[0...20]))
             xml.tag!('commerceIndicator', 'aesk')
             xml.tag!('xid', Base64.encode64(cryptogram[20...40]))
@@ -597,7 +617,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_capture_service(xml, request_id, request_token)
-        xml.tag! 'ccCaptureService', {'run' => 'true'} do
+        xml.tag! 'ccCaptureService', { 'run' => 'true' } do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
         end
@@ -605,52 +625,52 @@ module ActiveMerchant #:nodoc:
 
       def add_purchase_service(xml, payment_method, options)
         if options[:pinless_debit_card]
-          xml.tag! 'pinlessDebitService', {'run' => 'true'}
+          xml.tag! 'pinlessDebitService', { 'run' => 'true' }
         else
           add_auth_service(xml, payment_method, options)
-          xml.tag! 'ccCaptureService', {'run' => 'true'}
+          xml.tag! 'ccCaptureService', { 'run' => 'true' }
         end
       end
 
       def add_void_service(xml, request_id, request_token)
-        xml.tag! 'voidService', {'run' => 'true'} do
+        xml.tag! 'voidService', { 'run' => 'true' } do
           xml.tag! 'voidRequestID', request_id
           xml.tag! 'voidRequestToken', request_token
         end
       end
 
       def add_auth_reversal_service(xml, request_id, request_token)
-        xml.tag! 'ccAuthReversalService', {'run' => 'true'} do
+        xml.tag! 'ccAuthReversalService', { 'run' => 'true' } do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
         end
       end
 
       def add_credit_service(xml, request_id = nil, request_token = nil)
-        xml.tag! 'ccCreditService', {'run' => 'true'} do
+        xml.tag! 'ccCreditService', { 'run' => 'true' } do
           xml.tag! 'captureRequestID', request_id if request_id
           xml.tag! 'captureRequestToken', request_token if request_token
         end
       end
 
       def add_check_service(xml)
-        xml.tag! 'ecDebitService', {'run' => 'true'}
+        xml.tag! 'ecDebitService', { 'run' => 'true' }
       end
 
-      def add_subscription_create_service(xml, options)
-        xml.tag! 'paySubscriptionCreateService', {'run' => 'true'}
+      def add_subscription_create_service(xml, _options)
+        xml.tag! 'paySubscriptionCreateService', { 'run' => 'true' }
       end
 
-      def add_subscription_update_service(xml, options)
-        xml.tag! 'paySubscriptionUpdateService', {'run' => 'true'}
+      def add_subscription_update_service(xml, _options)
+        xml.tag! 'paySubscriptionUpdateService', { 'run' => 'true' }
       end
 
-      def add_subscription_delete_service(xml, options)
-        xml.tag! 'paySubscriptionDeleteService', {'run' => 'true'}
+      def add_subscription_delete_service(xml, _options)
+        xml.tag! 'paySubscriptionDeleteService', { 'run' => 'true' }
       end
 
-      def add_subscription_retrieve_service(xml, options)
-        xml.tag! 'paySubscriptionRetrieveService', {'run' => 'true'}
+      def add_subscription_retrieve_service(xml, _options)
+        xml.tag! 'paySubscriptionRetrieveService', { 'run' => 'true' }
       end
 
       def add_subscription(xml, options, reference = nil)
@@ -659,19 +679,47 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'recurringSubscriptionInfo' do
           if reference
             subscription_id = reference.split(';')[6]
-            xml.tag! 'subscriptionID',  subscription_id
+            xml.tag! 'subscriptionID', subscription_id
           end
 
-          xml.tag! 'status',            options[:subscription][:status]                         if options[:subscription][:status]
-          xml.tag! 'amount',            localized_amount(options[:subscription][:amount].to_i, options[:currency] || default_currency) if options[:subscription][:amount]
-          xml.tag! 'numberOfPayments',  options[:subscription][:occurrences]                    if options[:subscription][:occurrences]
-          xml.tag! 'automaticRenew',    options[:subscription][:automatic_renew]                if options[:subscription][:automatic_renew]
-          xml.tag! 'frequency',         options[:subscription][:frequency]                      if options[:subscription][:frequency]
-          xml.tag! 'startDate',         options[:subscription][:start_date].strftime('%Y%m%d')  if options[:subscription][:start_date]
-          xml.tag! 'endDate',           options[:subscription][:end_date].strftime('%Y%m%d')    if options[:subscription][:end_date]
-          xml.tag! 'approvalRequired',  options[:subscription][:approval_required] || false
-          xml.tag! 'event',             options[:subscription][:event]                          if options[:subscription][:event]
-          xml.tag! 'billPayment',       options[:subscription][:bill_payment]                   if options[:subscription][:bill_payment]
+          if options[:subscription][:status]
+            xml.tag! 'status',
+                     options[:subscription][:status]
+          end
+          if options[:subscription][:amount]
+            xml.tag! 'amount',
+                     localized_amount(options[:subscription][:amount].to_i,
+                                      options[:currency] || default_currency)
+          end
+          if options[:subscription][:occurrences]
+            xml.tag! 'numberOfPayments',
+                     options[:subscription][:occurrences]
+          end
+          if options[:subscription][:automatic_renew]
+            xml.tag! 'automaticRenew',
+                     options[:subscription][:automatic_renew]
+          end
+          if options[:subscription][:frequency]
+            xml.tag! 'frequency',
+                     options[:subscription][:frequency]
+          end
+          if options[:subscription][:start_date]
+            xml.tag! 'startDate',
+                     options[:subscription][:start_date].strftime('%Y%m%d')
+          end
+          if options[:subscription][:end_date]
+            xml.tag! 'endDate',
+                     options[:subscription][:end_date].strftime('%Y%m%d')
+          end
+          xml.tag! 'approvalRequired', options[:subscription][:approval_required] || false
+          if options[:subscription][:event]
+            xml.tag! 'event',
+                     options[:subscription][:event]
+          end
+          if options[:subscription][:bill_payment]
+            xml.tag! 'billPayment',
+                     options[:subscription][:bill_payment]
+          end
         end
       end
 
@@ -705,25 +753,37 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_validate_pinless_debit_service(xml)
-        xml.tag! 'pinlessDebitValidateService', {'run' => 'true'}
+        xml.tag! 'pinlessDebitValidateService', { 'run' => 'true' }
       end
 
       def add_threeds_services(xml, options)
-        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} do
-          xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
-          xml.tag! 'referenceID', options[:reference_id] if options[:reference_id]
-        end if options[:payer_auth_enroll_service]
+        if options[:payer_auth_enroll_service]
+          xml.tag! 'payerAuthEnrollService', { 'run' => 'true' } do
+            if options[:authentication_transaction_id]
+              xml.tag! 'authenticationTransactionID',
+                       options[:authentication_transaction_id]
+            end
+            xml.tag! 'referenceID', options[:reference_id] if options[:reference_id]
+          end
+        end
 
-        if options[:payer_auth_validate_service]
-          xml.tag! 'payerAuthValidateService', {'run' => 'true'} do
-            xml.tag! 'signedPARes', options[:pares] if options[:pares]
-            xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
+        return unless options[:payer_auth_validate_service]
+
+        xml.tag! 'payerAuthValidateService', { 'run' => 'true' } do
+          xml.tag! 'signedPARes', options[:pares] if options[:pares]
+          if options[:authentication_transaction_id]
+            xml.tag! 'authenticationTransactionID',
+                     options[:authentication_transaction_id]
           end
         end
       end
 
       def lookup_country_code(country_field)
-        country_code = Country.find(country_field) rescue nil
+        country_code = begin
+          Country.find(country_field)
+        rescue StandardError
+          nil
+        end
         country_code&.code(:alpha2)
       end
 
@@ -741,37 +801,156 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'subsequentAuthFirst', 'true' if options.dig(:stored_credential, :initial_transaction)
         network_transaction_id = options.dig(:stored_credential, :network_transaction_id)
 
-        xml.tag! 'subsequentAuthTransactionID', network_transaction_id if network_transaction_id && options.dig(:stored_credential, :initiator) == 'merchant'
+        xml.tag! 'subsequentAuthTransactionID', network_transaction_id if network_transaction_id && options.dig(
+          :stored_credential, :initiator
+        ) == 'merchant'
       end
 
       # Where we actually build the full SOAP request using builder
       def build_request(body, options)
-        xml = Builder::XmlMarkup.new :indent => 2
+        xml = Builder::XmlMarkup.new indent: 2
         xml.instruct!
-        xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
+        xml.tag! 's:Envelope', { 'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/' } do
           xml.tag! 's:Header' do
-            xml.tag! 'wsse:Security', {'s:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'} do
+            xml.tag! 'wsse:Security',
+                     { 's:mustUnderstand' => '1',
+                       'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' } do
               xml.tag! 'wsse:UsernameToken' do
                 xml.tag! 'wsse:Username', @options[:login]
                 xml.tag! 'wsse:Password', @options[:password], 'Type' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'
               end
             end
           end
-          xml.tag! 's:Body', {'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance', 'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema'} do
-            xml.tag! 'requestMessage', {'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{XSD_VERSION}"} do
+          xml.tag! 's:Body', {
+            'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+            'xmlns:xsd' => 'http://www.w3.org/2001/XMLSchema',
+            'xmlns:wsu' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd',
+            'wsu:Id' => 'Body'
+          } do
+            xml.tag! 'requestMessage', { 'xmlns' => "urn:schemas-cybersource-com:transaction-data-#{XSD_VERSION}" } do
               add_merchant_data(xml, options)
               xml << body
             end
           end
         end
-        xml.target!
+        if @options[:p12].present? && @options[:p12_password].present?
+          doc = Nokogiri::XML(xml.target!)
+
+          security_element = doc.at_xpath('//wsse:Security', 'wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd')
+          security_element.children.remove
+
+          token_element = generate_security_token(doc)
+          security_element.add_child(token_element)
+
+          signature_element = doc.create_element('ds:Signature')
+          signature_element.add_namespace('ds', DS_NS)
+          security_element.add_child(signature_element)
+
+          sign_info = build_signed_info(doc, ['Body'])
+          signature_element.add_child(sign_info)
+
+          signature = @private_key.sign(
+            OpenSSL::Digest.new('SHA256'),
+            canonicalize_node(sign_info)
+          )
+
+          signature_value = doc.create_element('ds:SignatureValue')
+          signature_value.content = Base64.strict_encode64(signature)
+          signature_element.add_child(signature_value)
+
+          key_info = doc.create_element('ds:KeyInfo')
+          security_token_reference = doc.create_element('wsse:SecurityTokenReference')
+          reference = doc.create_element('wsse:Reference')
+          reference['URI'] = '#X509Token'
+          security_token_reference.add_child(reference)
+          key_info.add_child(security_token_reference)
+          signature_element.add_child(key_info)
+          doc.to_xml
+        elsif @options[:p12].blank? ^ @options[:p12_password].blank?
+          raise ArgumentError, "Both p12 certificate contents ('@options[:p12]')and its password (''@options[:p12]'') must be provided together, or neither should be present."
+        else
+          xml.target!
+        end
+      end
+
+      def generate_security_token(doc)
+        cert = OpenSSL::PKCS12.new(@options[:p12], @options[:p12_password])
+        @private_key = cert.key
+        p12 = OpenSSL::PKCS12.new(@options[:p12], @options[:p12_password])
+        certificate = p12.certificate.to_pem
+
+        pubcert_lines = certificate.lines.map(&:strip) # Split and trim each line
+        pubcert_lines.shift # Remove "-----BEGIN CERTIFICATE-----"
+        pubcert_lines.pop while pubcert_lines.last.to_s.strip.empty? # Remove empty lines
+        pubcert_lines.pop if pubcert_lines.last == '-----END CERTIFICATE-----' # Remove "-----END CERTIFICATE-----"
+        pub_cert = pubcert_lines.join # Join without line breaks
+
+        token = doc.create_element('wsse:BinarySecurityToken', pub_cert)
+        token['xmlns:wsse'] = WSSE_NS
+        token['ValueType'] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3'
+        token['EncodingType'] = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary'
+        token['wsu:Id'] = 'X509Token'
+        token.set_attribute('xmlns:wsu', WSU_NS)
+        token
+      end
+
+      def build_signed_info(dom_document, ids)
+        xpath = Nokogiri::XML::XPathContext.new(dom_document)
+        xpath.register_ns('SOAP-ENV', SOAP_NS)
+        xpath.register_ns('wsu', WSU_NS)
+        xpath.register_ns('wsse', WSSE_NS)
+        xpath.register_ns('ds', DS_NS)
+
+        signed_info = Nokogiri::XML::Node.new('ds:SignedInfo', dom_document)
+        signed_info.add_namespace_definition('ds', DS_NS)
+
+        canonicalization_method = Nokogiri::XML::Node.new('ds:CanonicalizationMethod', dom_document)
+        canonicalization_method['Algorithm'] = 'http://www.w3.org/2001/10/xml-exc-c14n#'
+        signed_info.add_child(canonicalization_method)
+
+        signature_method = Nokogiri::XML::Node.new('ds:SignatureMethod', dom_document)
+        signature_method['Algorithm'] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        signed_info.add_child(signature_method)
+
+        ids.each do |id|
+          nodes = xpath.evaluate("//*[(@wsu:Id='#{id}')]")
+          next if nodes.empty?
+
+          node = nodes.first
+          canonicalized = canonicalize_node(node)
+
+          reference_element = Nokogiri::XML::Node.new('ds:Reference', dom_document)
+          reference_element['URI'] = "##{id}"
+
+          transforms = Nokogiri::XML::Node.new('ds:Transforms', dom_document)
+          transform_element = Nokogiri::XML::Node.new('ds:Transform', dom_document)
+          transform_element['Algorithm'] = 'http://www.w3.org/2001/10/xml-exc-c14n#'
+          transforms.add_child(transform_element)
+          reference_element.add_child(transforms)
+
+          digest_method = Nokogiri::XML::Node.new('ds:DigestMethod', dom_document)
+          digest_method['Algorithm'] = 'http://www.w3.org/2001/04/xmlenc#sha256'
+          reference_element.add_child(digest_method)
+
+          digest_value = Digest::SHA256.digest(canonicalized)
+          digest_value_node = Nokogiri::XML::Node.new('ds:DigestValue', dom_document)
+          digest_value_node.content = Base64.strict_encode64(digest_value)
+          reference_element.add_child(digest_value_node)
+
+          signed_info.add_child(reference_element)
+        end
+        signed_info
+      end
+
+      def canonicalize_node(node)
+        node.canonicalize(Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0)
       end
 
       # Contact CyberSource, make the SOAP request, and parse the reply into a
       # Response object
       def commit(request, action, amount, options)
         begin
-          raw_response = ssl_post(test? ? self.test_url : self.live_url, build_request(request, options))
+          raw_response = ssl_post(test? ? test_url : live_url, build_request(request, options))
         rescue ResponseError => e
           raw_response = e.response.body
         end
@@ -784,24 +963,25 @@ module ActiveMerchant #:nodoc:
 
         success = response[:decision] == 'ACCEPT'
 
-        response_code = ('r' + response.fetch(:reasonCode,'')).to_sym
+        response_code = "r#{response.fetch(:reasonCode, '')}".to_sym
         # CyberSource sometimes returns a REJECT with reason_code 100.
         # Set message to 'Failure' instead of 'Successful transaction' in that case.
-        message = (!success && response_code == :r100) ? "Failure" : @@response_codes[response_code] rescue response[:message]
+        message = begin
+          !success && response_code == :r100 ? 'Failure' : @@response_codes[response_code]
+        rescue StandardError
+          response[:message]
+        end
 
         # if a <soap::Fault> is in the return xml there wont be a reasonCode
-        if !success && @@response_codes[response_code].nil?
-          message = response[:message]
-        end
+        message = response[:message] if !success && @@response_codes[response_code].nil?
 
         authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
-          :test => test?,
-          :authorization => authorization,
-          :avs_result => { :code => response[:avsCode] },
-          :cvv_result => response[:cvCode]
-        )
+                     test: test?,
+                     authorization: authorization,
+                     avs_result: { code: response[:avsCode] },
+                     cvv_result: response[:cvCode])
       end
 
       # Parse the SOAP response
@@ -809,7 +989,7 @@ module ActiveMerchant #:nodoc:
       def parse(xml)
         reply = {}
         xml = REXML::Document.new(xml)
-        if root = REXML::XPath.first(xml, '//c:replyMessage')
+        if (root = REXML::XPath.first(xml, '//c:replyMessage'))
           root.elements.to_a.each do |node|
             case node.expanded_name
             when 'c:reasonCode'
@@ -819,11 +999,11 @@ module ActiveMerchant #:nodoc:
               parse_element(reply, node)
             end
           end
-        elsif root = REXML::XPath.first(xml, '//soap:Fault')
+        elsif (root = REXML::XPath.first(xml, '//soap:Fault'))
           parse_element(reply, root)
           reply[:message] = "#{reply[:faultcode]}: #{reply[:faultstring]}"
         end
-        return reply
+        reply
       end
 
       def parse_element(reply, node)
@@ -832,16 +1012,17 @@ module ActiveMerchant #:nodoc:
         else
           if node.parent.name =~ /item/
             parent = node.parent.name
-            parent += '_' + node.parent.attributes['id'] if node.parent.attributes['id']
+            parent += "_#{node.parent.attributes['id']}" if node.parent.attributes['id']
             parent += '_'
           end
           reply["#{parent}#{node.name}".to_sym] ||= node.text
         end
-        return reply
+        reply
       end
 
       def reason_message(reason_code)
         return if reason_code.blank?
+
         @@response_codes[:"r#{reason_code}"]
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -760,9 +760,7 @@ module ActiveMerchant #:nodoc:
         xml.instruct!
         xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
           xml.tag! 's:Header' do
-            xml.tag! 'wsse:Security',
-                     { 's:mustUnderstand' => '1',
-                       'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd' } do
+            xml.tag! 'wsse:Security', {'s:mustUnderstand' => '1', 'xmlns:wsse' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'} do
               xml.tag! 'wsse:UsernameToken' do
                 xml.tag! 'wsse:Username', @options[:login]
                 xml.tag! 'wsse:Password', @options[:password], 'Type' => 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText'

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -102,6 +102,10 @@ module ActiveMerchant # :nodoc:
       #
       # :password =>  the transaction key you generated in the Business Center
       #
+      # :p12 => the contents of your .p12 file
+      #
+      # :p12_password => the password you set on your .p12 file
+      #
       # :test => true   sets the gateway to test mode
       #
       # :vat_reg_number => your VAT registration number
@@ -115,7 +119,7 @@ module ActiveMerchant # :nodoc:
       # :ignore_cvv => true   don't want to use CVV so continue processing even
       #                       if CVV would have failed
       def initialize(options = {})
-        requires!(options, :login, :password)
+        requires!(options, :login, :password, :p12, :p12_password)
         super
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -862,6 +862,8 @@ module ActiveMerchant #:nodoc:
         token['wsu:Id'] = 'X509Token'
         token.set_attribute('xmlns:wsu', WSU_NS)
         token
+      rescue OpenSSL::PKCS12::PKCS12Error => e
+        raise ArgumentError, "Invalid p12 certificate or password provided: #{e.message}"
       end
 
       def build_signed_info(dom_document, ids)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -32,8 +32,8 @@ module ActiveMerchant #:nodoc:
       SOAP_NS = 'http://schemas.xmlsoap.org/soap/envelope/'.freeze
       DS_NS = 'http://www.w3.org/2000/09/xmldsig#'.freeze
 
-      self.supported_cardtypes = %i[visa master american_express discover diners_club jcb dankort maestro]
-      self.supported_countries = %w[US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB ZA]
+      self.supported_cardtypes = [:visa, :master, :american_express, :discover, :diners_club, :jcb, :dankort, :maestro]
+      self.supported_countries = %w(US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB ZA)
 
       self.default_currency = 'USD'
       self.currencies_without_fractions = %w(JPY)
@@ -948,10 +948,10 @@ module ActiveMerchant #:nodoc:
         authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
-                     :test => test?,
-                     :authorization => authorization,
-                     :avs_result => { :code => response[:avsCode] },
-                     :cvv_result => response[:cvCode]
+          :test => test?,
+          :authorization => authorization,
+          :avs_result => { :code => response[:avsCode] },
+          :cvv_result => response[:cvCode]
         )
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -1,5 +1,5 @@
-module ActiveMerchant # :nodoc:
-  module Billing # :nodoc:
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
     # Initial setup instructions can be found in
     # http://cybersource.com/support_center/implementation/downloads/soap_api/SOAP_toolkits.pdf
     #
@@ -24,7 +24,7 @@ module ActiveMerchant # :nodoc:
       self.test_url = 'https://ics2wstesta.ic3.com/commerce/1.x/transactionProcessor'
       self.live_url = 'https://ics2wsa.ic3.com/commerce/1.x/transactionProcessor'
 
-      XSD_VERSION = '1.153'.freeze
+      XSD_VERSION = '1.153'
 
       # Constants for p12 cert auth
       WSU_NS = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'.freeze
@@ -36,63 +36,63 @@ module ActiveMerchant # :nodoc:
       self.supported_countries = %w[US BR CA CN DK FI FR DE IN JP MX NO SE GB SG LB ZA]
 
       self.default_currency = 'USD'
-      self.currencies_without_fractions = %w[JPY]
+      self.currencies_without_fractions = %w(JPY)
 
       self.homepage_url = 'http://www.cybersource.com'
       self.display_name = 'CyberSource'
 
       @@credit_card_codes = {
-        visa: '001',
-        master: '002',
-        american_express: '003',
-        discover: '004',
-        diners_club: '005',
-        jcb: '007',
-        dankort: '034',
-        maestro: '042'
+        :visa  => '001',
+        :master => '002',
+        :american_express => '003',
+        :discover => '004',
+        :diners_club => '005',
+        :jcb => '007',
+        :dankort => '034',
+        :maestro => '042'
       }
 
       @@response_codes = {
-        r100: 'Successful transaction',
-        r101: 'Request is missing one or more required fields',
-        r102: 'One or more fields contains invalid data',
-        r150: 'General failure',
-        r151: 'The request was received but a server time-out occurred',
-        r152: 'The request was received, but a service timed out',
-        r200: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
-        r201: 'The issuing bank has questions about the request',
-        r202: 'Expired card',
-        r203: 'General decline of the card',
-        r204: 'Insufficient funds in the account',
-        r205: 'Stolen or lost card',
-        r207: 'Issuing bank unavailable',
-        r208: 'Inactive card or card not authorized for card-not-present transactions',
-        r209: 'American Express Card Identifiction Digits (CID) did not match',
-        r210: 'The card has reached the credit limit',
-        r211: 'Invalid card verification number',
-        r221: "The customer matched an entry on the processor's negative file",
-        r230: 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
-        r231: 'Invalid account number',
-        r232: 'The card type is not accepted by the payment processor',
-        r233: 'General decline by the processor',
-        r234: 'A problem exists with your CyberSource merchant configuration',
-        r235: 'The requested amount exceeds the originally authorized amount',
-        r236: 'Processor failure',
-        r237: 'The authorization has already been reversed',
-        r238: 'The authorization has already been captured',
-        r239: 'The requested transaction amount must match the previous transaction amount',
-        r240: 'The card type sent is invalid or does not correlate with the credit card number',
-        r241: 'The request ID is invalid',
-        r242: 'You requested a capture, but there is no corresponding, unused authorization record.',
-        r243: 'The transaction has already been settled or reversed',
-        r244: 'The bank account number failed the validation check',
-        r246: 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
-        r247: 'You requested a credit for a capture that was previously voided',
-        r250: 'The request was received, but a time-out occurred with the payment processor',
-        r254: 'Your CyberSource account is prohibited from processing stand-alone refunds',
-        r255: 'Your CyberSource account is not configured to process the service in the country you specified',
-        r475: 'The customer is enrolled in payer authentication. Authenticate the cardholder before continuing with the transaction.',
-        r476: 'The customer cannot be authenticated'
+        :r100 => 'Successful transaction',
+        :r101 => 'Request is missing one or more required fields',
+        :r102 => 'One or more fields contains invalid data',
+        :r150 => 'General failure',
+        :r151 => 'The request was received but a server time-out occurred',
+        :r152 => 'The request was received, but a service timed out',
+        :r200 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the AVS check',
+        :r201 => 'The issuing bank has questions about the request',
+        :r202 => 'Expired card',
+        :r203 => 'General decline of the card',
+        :r204 => 'Insufficient funds in the account',
+        :r205 => 'Stolen or lost card',
+        :r207 => 'Issuing bank unavailable',
+        :r208 => 'Inactive card or card not authorized for card-not-present transactions',
+        :r209 => 'American Express Card Identifiction Digits (CID) did not match',
+        :r210 => 'The card has reached the credit limit',
+        :r211 => 'Invalid card verification number',
+        :r221 => "The customer matched an entry on the processor's negative file",
+        :r230 => 'The authorization request was approved by the issuing bank but declined by CyberSource because it did not pass the card verification check',
+        :r231 => 'Invalid account number',
+        :r232 => 'The card type is not accepted by the payment processor',
+        :r233 => 'General decline by the processor',
+        :r234 => 'A problem exists with your CyberSource merchant configuration',
+        :r235 => 'The requested amount exceeds the originally authorized amount',
+        :r236 => 'Processor failure',
+        :r237 => 'The authorization has already been reversed',
+        :r238 => 'The authorization has already been captured',
+        :r239 => 'The requested transaction amount must match the previous transaction amount',
+        :r240 => 'The card type sent is invalid or does not correlate with the credit card number',
+        :r241 => 'The request ID is invalid',
+        :r242 => 'You requested a capture, but there is no corresponding, unused authorization record.',
+        :r243 => 'The transaction has already been settled or reversed',
+        :r244 => 'The bank account number failed the validation check',
+        :r246 => 'The capture or credit is not voidable because the capture or credit information has already been submitted to your processor',
+        :r247 => 'You requested a credit for a capture that was previously voided',
+        :r250 => 'The request was received, but a time-out occurred with the payment processor',
+        :r254 => 'Your CyberSource account is prohibited from processing stand-alone refunds',
+        :r255 => 'Your CyberSource account is not configured to process the service in the country you specified',
+        :r475 => 'The customer is enrolled in payer authentication. Authenticate the cardholder before continuing with the transaction.',
+        :r476 => 'The customer cannot be authenticated'
       }
 
       # These are the options that can be used when creating a new CyberSource
@@ -214,7 +214,7 @@ module ActiveMerchant # :nodoc:
       # This functionality is only supported by this particular gateway may
       # be changed at any time
       def calculate_tax(creditcard, options)
-        requires!(options, :line_items)
+        requires!(options,  :line_items)
         setup_address_hash(options)
         commit(build_tax_calculation_request(creditcard, options), :calculate_tax, nil, options)
       end
@@ -230,13 +230,13 @@ module ActiveMerchant # :nodoc:
       end
 
       def scrub(transcript)
-        transcript
-          .gsub(%r{(<wsse:Password [^>]*>)[^<]*(</wsse:Password>)}i, '\1[FILTERED]\2')
-          .gsub(%r{(<accountNumber>)[^<]*(</accountNumber>)}i, '\1[FILTERED]\2')
-          .gsub(%r{(<cvNumber>)[^<]*(</cvNumber>)}i, '\1[FILTERED]\2')
-          .gsub(%r{(<cavv>)[^<]*(</cavv>)}i, '\1[FILTERED]\2')
-          .gsub(%r{(<xid>)[^<]*(</xid>)}i, '\1[FILTERED]\2')
-          .gsub(%r{(<authenticationData>)[^<]*(</authenticationData>)}i, '\1[FILTERED]\2')
+        transcript.
+          gsub(%r((<wsse:Password [^>]*>)[^<]*(</wsse:Password>))i, '\1[FILTERED]\2').
+          gsub(%r((<accountNumber>)[^<]*(</accountNumber>))i, '\1[FILTERED]\2').
+          gsub(%r((<cvNumber>)[^<]*(</cvNumber>))i, '\1[FILTERED]\2').
+          gsub(%r((<cavv>)[^<]*(</cavv>))i, '\1[FILTERED]\2').
+          gsub(%r((<xid>)[^<]*(</xid>))i, '\1[FILTERED]\2').
+          gsub(%r((<authenticationData>)[^<]*(</authenticationData>))i, '\1[FILTERED]\2')
       end
 
       def supports_network_tokenization?
@@ -254,18 +254,18 @@ module ActiveMerchant # :nodoc:
       # were only provided with one or two of them or even none
       def setup_address_hash(options)
         default_address = {
-          address1: 'Unspecified',
-          city: 'Unspecified',
-          state: 'NC',
-          zip: '00000',
-          country: 'US'
+          :address1 => 'Unspecified',
+          :city => 'Unspecified',
+          :state => 'NC',
+          :zip => '00000',
+          :country => 'US'
         }
         options[:billing_address] = options[:billing_address] || options[:address] || default_address
         options[:shipping_address] = options[:shipping_address] || {}
       end
 
       def build_auth_request(money, creditcard_or_reference, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_payment_method_or_subscription(xml, money, creditcard_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -279,7 +279,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_tax_calculation_request(creditcard, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_address(xml, creditcard, options[:billing_address], options, false)
         add_address(xml, creditcard, options[:shipping_address], options, true)
         add_line_item_data(xml, options)
@@ -293,7 +293,7 @@ module ActiveMerchant # :nodoc:
         order_id, request_id, request_token = authorization.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_purchase_data(xml, money, true, options)
         add_capture_service(xml, request_id, request_token)
         add_business_rules_data(xml, authorization, options)
@@ -301,7 +301,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_purchase_request(money, payment_method_or_reference, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         add_decision_manager_fields(xml, options)
         add_mdd_fields(xml, options)
@@ -319,14 +319,14 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_void_request(identification, options)
-        order_id, request_id, request_token, action, money, currency = identification.split(';')
+        order_id, request_id, request_token, action, money, currency  = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         if action == 'capture'
           add_void_service(xml, request_id, request_token)
         else
-          add_purchase_data(xml, money.to_i, true, options.merge(currency: currency || default_currency))
+          add_purchase_data(xml, money.to_i, true, options.merge(:currency => currency || default_currency))
           add_auth_reversal_service(xml, request_id, request_token)
         end
         xml.target!
@@ -336,7 +336,7 @@ module ActiveMerchant # :nodoc:
         order_id, request_id, request_token = identification.split(';')
         options[:order_id] = order_id
 
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_purchase_data(xml, money, true, options)
         add_credit_service(xml, request_id, request_token)
 
@@ -344,7 +344,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_credit_request(money, reference, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
 
         add_purchase_data(xml, money, true, options)
         add_subscription(xml, options, reference)
@@ -354,12 +354,12 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_create_subscription_request(payment_method, options)
-        default_subscription_params = { frequency: 'on-demand', amount: 0, automatic_renew: false }
+        default_subscription_params = {:frequency => 'on-demand', :amount => 0, :automatic_renew => false}
         options[:subscription] = default_subscription_params.update(
           options[:subscription] || {}
         )
 
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_address(xml, payment_method, options[:billing_address], options)
         add_purchase_data(xml, options[:setup_fee] || 0, true, options)
         if card_brand(payment_method) == 'check'
@@ -384,7 +384,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_update_subscription_request(reference, creditcard, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_address(xml, creditcard, options[:billing_address], options) unless options[:billing_address].blank?
         add_purchase_data(xml, options[:setup_fee], true, options) unless options[:setup_fee].blank?
         add_creditcard(xml, creditcard)    if creditcard
@@ -396,21 +396,21 @@ module ActiveMerchant # :nodoc:
       end
 
       def build_delete_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_subscription(xml, options, reference)
         add_subscription_delete_service(xml, options)
         xml.target!
       end
 
       def build_retrieve_subscription_request(reference, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         add_subscription(xml, options, reference)
         add_subscription_retrieve_service(xml, options)
         xml.target!
       end
 
-      def build_validate_pinless_debit_request(creditcard, _options)
-        xml = Builder::XmlMarkup.new indent: 2
+      def build_validate_pinless_debit_request(creditcard, options)
+        xml = Builder::XmlMarkup.new :indent => 2
         add_creditcard(xml, creditcard)
         add_validate_pinless_debit_service(xml)
         xml.target!
@@ -419,24 +419,24 @@ module ActiveMerchant # :nodoc:
       def add_business_rules_data(xml, payment_method, options)
         prioritized_options = [options, @options]
 
-        return if network_tokenization?(payment_method)
-
-        xml.tag! 'businessRules' do
-          xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
-          xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)
+        unless network_tokenization?(payment_method)
+          xml.tag! 'businessRules' do
+            xml.tag!('ignoreAVSResult', 'true') if extract_option(prioritized_options, :ignore_avs)
+            xml.tag!('ignoreCVResult', 'true') if extract_option(prioritized_options, :ignore_cvv)
+          end
         end
       end
 
       def extract_option(prioritized_options, option_name)
         options_matching_key = prioritized_options.detect do |options|
-          options.key? option_name
+          options.has_key? option_name
         end
         options_matching_key[option_name] if options_matching_key
       end
 
       def add_line_item_data(xml, options)
         options[:line_items].each_with_index do |value, index|
-          xml.tag! 'item', { 'id' => index } do
+          xml.tag! 'item', {'id' => index} do
             xml.tag! 'unitPrice', localized_amount(value[:declared_value].to_i, options[:currency] || default_currency)
             xml.tag! 'quantity', value[:quantity]
             xml.tag! 'productCode', value[:code] || 'shipping_only'
@@ -450,7 +450,7 @@ module ActiveMerchant # :nodoc:
         xml.tag! 'merchantID', @options[:login]
         xml.tag! 'merchantReferenceCode', options[:order_id] || generate_unique_id
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
-        xml.tag! 'clientLibraryVersion', VERSION
+        xml.tag! 'clientLibraryVersion',  VERSION
         xml.tag! 'clientEnvironment', RUBY_PLATFORM
         add_merchant_descriptor(xml, options)
       end
@@ -463,13 +463,10 @@ module ActiveMerchant # :nodoc:
         end
       end
 
-      def add_purchase_data(xml, money = 0, include_grand_total = false, options = {})
+      def add_purchase_data(xml, money = 0, include_grand_total = false, options={})
         xml.tag! 'purchaseTotals' do
           xml.tag! 'currency', options[:currency] || currency(money)
-          if include_grand_total
-            xml.tag!('grandTotalAmount',
-                     localized_amount(money, options[:currency] || default_currency))
-          end
+          xml.tag!('grandTotalAmount', localized_amount(money, options[:currency] || default_currency))  if include_grand_total
         end
       end
 
@@ -487,15 +484,9 @@ module ActiveMerchant # :nodoc:
           xml.tag! 'companyTaxID',          address[:companyTaxID]            unless address[:company_tax_id].blank?
           xml.tag! 'phoneNumber',           address[:phone]                   unless address[:phone].blank?
           xml.tag! 'email',                 options[:email] || 'null@cybersource.com'
-          xml.tag! 'ipAddress',             options[:ip] unless options[:ip].blank? || shipTo
-          unless options[:drivers_license_number].blank?
-            xml.tag! 'driversLicenseNumber',
-                     options[:drivers_license_number]
-          end
-          unless options[:drivers_license_state].blank?
-            xml.tag! 'driversLicenseState',
-                     options[:drivers_license_state]
-          end
+          xml.tag! 'ipAddress',             options[:ip]                      unless options[:ip].blank? || shipTo
+          xml.tag! 'driversLicenseNumber',  options[:drivers_license_number]  unless options[:drivers_license_number].blank?
+          xml.tag! 'driversLicenseState',   options[:drivers_license_state]   unless options[:drivers_license_state].blank?
         end
       end
 
@@ -512,10 +503,7 @@ module ActiveMerchant # :nodoc:
           xml.tag!('accountNumber', creditcard.number) unless creditcard.number.blank?
           xml.tag! 'expirationMonth', format(creditcard.month, :two_digits)
           xml.tag! 'expirationYear', format(creditcard.year, :four_digits)
-          unless @options[:ignore_cvv] || creditcard.verification_value.blank?
-            xml.tag!('cvNumber',
-                     creditcard.verification_value)
-          end
+          xml.tag!('cvNumber', creditcard.verification_value) unless @options[:ignore_cvv] || creditcard.verification_value.blank?
           xml.tag! 'cardType', @@credit_card_codes[card_brand(creditcard).to_sym]
         end
       end
@@ -549,7 +537,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_tax_service(xml)
-        xml.tag! 'taxService', { 'run' => 'true' } do
+        xml.tag! 'taxService', {'run' => 'true'} do
           xml.tag!('nexus', @options[:nexus]) unless @options[:nexus].blank?
           xml.tag!('sellerRegistration', @options[:vat_reg_number]) unless @options[:vat_reg_number].blank?
         end
@@ -559,7 +547,7 @@ module ActiveMerchant # :nodoc:
         if network_tokenization?(payment_method)
           add_auth_network_tokenization(xml, payment_method, options)
         else
-          xml.tag! 'ccAuthService', { 'run' => 'true' } do
+          xml.tag! 'ccAuthService', {'run' => 'true'} do
             check_for_stored_cred_commerce_indicator(xml, options)
           end
         end
@@ -567,15 +555,13 @@ module ActiveMerchant # :nodoc:
 
       def check_for_stored_cred_commerce_indicator(xml, options)
         return unless options[:stored_credential]
-
-        return unless commerce_indicator(options)
-
-        xml.tag!('commerceIndicator', commerce_indicator(options))
+        if commerce_indicator(options)
+          xml.tag!('commerceIndicator', commerce_indicator(options))
+        end
       end
 
       def commerce_indicator(options)
         return if options[:stored_credential][:initial_transaction]
-
         case options[:stored_credential][:reason_type]
         when 'installment' then 'install'
         when 'recurring' then 'recurring'
@@ -586,12 +572,12 @@ module ActiveMerchant # :nodoc:
         payment_method.is_a?(NetworkTokenizationCreditCard)
       end
 
-      def add_auth_network_tokenization(xml, payment_method, _options)
+      def add_auth_network_tokenization(xml, payment_method, options)
         return unless network_tokenization?(payment_method)
 
         case card_brand(payment_method).to_sym
         when :visa
-          xml.tag! 'ccAuthService', { 'run' => 'true' } do
+          xml.tag! 'ccAuthService', {'run' => 'true'} do
             xml.tag!('cavv', payment_method.payment_cryptogram)
             xml.tag!('commerceIndicator', 'vbv')
             xml.tag!('xid', payment_method.payment_cryptogram)
@@ -601,12 +587,12 @@ module ActiveMerchant # :nodoc:
             xml.tag!('authenticationData', payment_method.payment_cryptogram)
             xml.tag!('collectionIndicator', '2')
           end
-          xml.tag! 'ccAuthService', { 'run' => 'true' } do
+          xml.tag! 'ccAuthService', {'run' => 'true'} do
             xml.tag!('commerceIndicator', 'spa')
           end
         when :american_express
           cryptogram = Base64.decode64(payment_method.payment_cryptogram)
-          xml.tag! 'ccAuthService', { 'run' => 'true' } do
+          xml.tag! 'ccAuthService', {'run' => 'true'} do
             xml.tag!('cavv', Base64.encode64(cryptogram[0...20]))
             xml.tag!('commerceIndicator', 'aesk')
             xml.tag!('xid', Base64.encode64(cryptogram[20...40]))
@@ -621,7 +607,7 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_capture_service(xml, request_id, request_token)
-        xml.tag! 'ccCaptureService', { 'run' => 'true' } do
+        xml.tag! 'ccCaptureService', {'run' => 'true'} do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
         end
@@ -629,52 +615,52 @@ module ActiveMerchant # :nodoc:
 
       def add_purchase_service(xml, payment_method, options)
         if options[:pinless_debit_card]
-          xml.tag! 'pinlessDebitService', { 'run' => 'true' }
+          xml.tag! 'pinlessDebitService', {'run' => 'true'}
         else
           add_auth_service(xml, payment_method, options)
-          xml.tag! 'ccCaptureService', { 'run' => 'true' }
+          xml.tag! 'ccCaptureService', {'run' => 'true'}
         end
       end
 
       def add_void_service(xml, request_id, request_token)
-        xml.tag! 'voidService', { 'run' => 'true' } do
+        xml.tag! 'voidService', {'run' => 'true'} do
           xml.tag! 'voidRequestID', request_id
           xml.tag! 'voidRequestToken', request_token
         end
       end
 
       def add_auth_reversal_service(xml, request_id, request_token)
-        xml.tag! 'ccAuthReversalService', { 'run' => 'true' } do
+        xml.tag! 'ccAuthReversalService', {'run' => 'true'} do
           xml.tag! 'authRequestID', request_id
           xml.tag! 'authRequestToken', request_token
         end
       end
 
       def add_credit_service(xml, request_id = nil, request_token = nil)
-        xml.tag! 'ccCreditService', { 'run' => 'true' } do
+        xml.tag! 'ccCreditService', {'run' => 'true'} do
           xml.tag! 'captureRequestID', request_id if request_id
           xml.tag! 'captureRequestToken', request_token if request_token
         end
       end
 
       def add_check_service(xml)
-        xml.tag! 'ecDebitService', { 'run' => 'true' }
+        xml.tag! 'ecDebitService', {'run' => 'true'}
       end
 
-      def add_subscription_create_service(xml, _options)
-        xml.tag! 'paySubscriptionCreateService', { 'run' => 'true' }
+      def add_subscription_create_service(xml, options)
+        xml.tag! 'paySubscriptionCreateService', {'run' => 'true'}
       end
 
-      def add_subscription_update_service(xml, _options)
-        xml.tag! 'paySubscriptionUpdateService', { 'run' => 'true' }
+      def add_subscription_update_service(xml, options)
+        xml.tag! 'paySubscriptionUpdateService', {'run' => 'true'}
       end
 
-      def add_subscription_delete_service(xml, _options)
-        xml.tag! 'paySubscriptionDeleteService', { 'run' => 'true' }
+      def add_subscription_delete_service(xml, options)
+        xml.tag! 'paySubscriptionDeleteService', {'run' => 'true'}
       end
 
-      def add_subscription_retrieve_service(xml, _options)
-        xml.tag! 'paySubscriptionRetrieveService', { 'run' => 'true' }
+      def add_subscription_retrieve_service(xml, options)
+        xml.tag! 'paySubscriptionRetrieveService', {'run' => 'true'}
       end
 
       def add_subscription(xml, options, reference = nil)
@@ -683,47 +669,19 @@ module ActiveMerchant # :nodoc:
         xml.tag! 'recurringSubscriptionInfo' do
           if reference
             subscription_id = reference.split(';')[6]
-            xml.tag! 'subscriptionID', subscription_id
+            xml.tag! 'subscriptionID',  subscription_id
           end
 
-          if options[:subscription][:status]
-            xml.tag! 'status',
-                     options[:subscription][:status]
-          end
-          if options[:subscription][:amount]
-            xml.tag! 'amount',
-                     localized_amount(options[:subscription][:amount].to_i,
-                                      options[:currency] || default_currency)
-          end
-          if options[:subscription][:occurrences]
-            xml.tag! 'numberOfPayments',
-                     options[:subscription][:occurrences]
-          end
-          if options[:subscription][:automatic_renew]
-            xml.tag! 'automaticRenew',
-                     options[:subscription][:automatic_renew]
-          end
-          if options[:subscription][:frequency]
-            xml.tag! 'frequency',
-                     options[:subscription][:frequency]
-          end
-          if options[:subscription][:start_date]
-            xml.tag! 'startDate',
-                     options[:subscription][:start_date].strftime('%Y%m%d')
-          end
-          if options[:subscription][:end_date]
-            xml.tag! 'endDate',
-                     options[:subscription][:end_date].strftime('%Y%m%d')
-          end
-          xml.tag! 'approvalRequired', options[:subscription][:approval_required] || false
-          if options[:subscription][:event]
-            xml.tag! 'event',
-                     options[:subscription][:event]
-          end
-          if options[:subscription][:bill_payment]
-            xml.tag! 'billPayment',
-                     options[:subscription][:bill_payment]
-          end
+          xml.tag! 'status',            options[:subscription][:status]                         if options[:subscription][:status]
+          xml.tag! 'amount',            localized_amount(options[:subscription][:amount].to_i, options[:currency] || default_currency) if options[:subscription][:amount]
+          xml.tag! 'numberOfPayments',  options[:subscription][:occurrences]                    if options[:subscription][:occurrences]
+          xml.tag! 'automaticRenew',    options[:subscription][:automatic_renew]                if options[:subscription][:automatic_renew]
+          xml.tag! 'frequency',         options[:subscription][:frequency]                      if options[:subscription][:frequency]
+          xml.tag! 'startDate',         options[:subscription][:start_date].strftime('%Y%m%d')  if options[:subscription][:start_date]
+          xml.tag! 'endDate',           options[:subscription][:end_date].strftime('%Y%m%d')    if options[:subscription][:end_date]
+          xml.tag! 'approvalRequired',  options[:subscription][:approval_required] || false
+          xml.tag! 'event',             options[:subscription][:event]                          if options[:subscription][:event]
+          xml.tag! 'billPayment',       options[:subscription][:bill_payment]                   if options[:subscription][:bill_payment]
         end
       end
 
@@ -757,37 +715,25 @@ module ActiveMerchant # :nodoc:
       end
 
       def add_validate_pinless_debit_service(xml)
-        xml.tag! 'pinlessDebitValidateService', { 'run' => 'true' }
+        xml.tag! 'pinlessDebitValidateService', {'run' => 'true'}
       end
 
       def add_threeds_services(xml, options)
-        if options[:payer_auth_enroll_service]
-          xml.tag! 'payerAuthEnrollService', { 'run' => 'true' } do
-            if options[:authentication_transaction_id]
-              xml.tag! 'authenticationTransactionID',
-                       options[:authentication_transaction_id]
-            end
-            xml.tag! 'referenceID', options[:reference_id] if options[:reference_id]
-          end
-        end
+        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} do
+          xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
+          xml.tag! 'referenceID', options[:reference_id] if options[:reference_id]
+        end if options[:payer_auth_enroll_service]
 
-        return unless options[:payer_auth_validate_service]
-
-        xml.tag! 'payerAuthValidateService', { 'run' => 'true' } do
-          xml.tag! 'signedPARes', options[:pares] if options[:pares]
-          if options[:authentication_transaction_id]
-            xml.tag! 'authenticationTransactionID',
-                     options[:authentication_transaction_id]
+        if options[:payer_auth_validate_service]
+          xml.tag! 'payerAuthValidateService', {'run' => 'true'} do
+            xml.tag! 'signedPARes', options[:pares] if options[:pares]
+            xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
           end
         end
       end
 
       def lookup_country_code(country_field)
-        country_code = begin
-          Country.find(country_field)
-        rescue StandardError
-          nil
-        end
+        country_code = Country.find(country_field) rescue nil
         country_code&.code(:alpha2)
       end
 
@@ -805,16 +751,14 @@ module ActiveMerchant # :nodoc:
         xml.tag! 'subsequentAuthFirst', 'true' if options.dig(:stored_credential, :initial_transaction)
         network_transaction_id = options.dig(:stored_credential, :network_transaction_id)
 
-        xml.tag! 'subsequentAuthTransactionID', network_transaction_id if network_transaction_id && options.dig(
-          :stored_credential, :initiator
-        ) == 'merchant'
+        xml.tag! 'subsequentAuthTransactionID', network_transaction_id if network_transaction_id && options.dig(:stored_credential, :initiator) == 'merchant'
       end
 
       # Where we actually build the full SOAP request using builder
       def build_request(body, options)
-        xml = Builder::XmlMarkup.new indent: 2
+        xml = Builder::XmlMarkup.new :indent => 2
         xml.instruct!
-        xml.tag! 's:Envelope', { 'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/' } do
+        xml.tag! 's:Envelope', {'xmlns:s' => 'http://schemas.xmlsoap.org/soap/envelope/'} do
           xml.tag! 's:Header' do
             xml.tag! 'wsse:Security',
                      { 's:mustUnderstand' => '1',
@@ -978,7 +922,7 @@ module ActiveMerchant # :nodoc:
       # Response object
       def commit(request, action, amount, options)
         begin
-          raw_response = ssl_post(test? ? test_url : live_url, build_request(request, options))
+          raw_response = ssl_post(test? ? self.test_url : self.live_url, build_request(request, options))
         rescue ResponseError => e
           raw_response = e.response.body
         end
@@ -991,25 +935,24 @@ module ActiveMerchant # :nodoc:
 
         success = response[:decision] == 'ACCEPT'
 
-        response_code = "r#{response.fetch(:reasonCode, '')}".to_sym
+        response_code = ('r' + response.fetch(:reasonCode,'')).to_sym
         # CyberSource sometimes returns a REJECT with reason_code 100.
         # Set message to 'Failure' instead of 'Successful transaction' in that case.
-        message = begin
-          !success && response_code == :r100 ? 'Failure' : @@response_codes[response_code]
-        rescue StandardError
-          response[:message]
-        end
+        message = (!success && response_code == :r100) ? "Failure" : @@response_codes[response_code] rescue response[:message]
 
         # if a <soap::Fault> is in the return xml there wont be a reasonCode
-        message = response[:message] if !success && @@response_codes[response_code].nil?
+        if !success && @@response_codes[response_code].nil?
+          message = response[:message]
+        end
 
         authorization = success ? authorization_from(response, action, amount, options) : nil
 
         Response.new(success, message, response,
-                     test: test?,
-                     authorization: authorization,
-                     avs_result: { code: response[:avsCode] },
-                     cvv_result: response[:cvCode])
+                     :test => test?,
+                     :authorization => authorization,
+                     :avs_result => { :code => response[:avsCode] },
+                     :cvv_result => response[:cvCode]
+        )
       end
 
       # Parse the SOAP response
@@ -1017,7 +960,7 @@ module ActiveMerchant # :nodoc:
       def parse(xml)
         reply = {}
         xml = REXML::Document.new(xml)
-        if (root = REXML::XPath.first(xml, '//c:replyMessage'))
+        if root = REXML::XPath.first(xml, '//c:replyMessage')
           root.elements.to_a.each do |node|
             case node.expanded_name
             when 'c:reasonCode'
@@ -1027,11 +970,11 @@ module ActiveMerchant # :nodoc:
               parse_element(reply, node)
             end
           end
-        elsif (root = REXML::XPath.first(xml, '//soap:Fault'))
+        elsif root = REXML::XPath.first(xml, '//soap:Fault')
           parse_element(reply, root)
           reply[:message] = "#{reply[:faultcode]}: #{reply[:faultstring]}"
         end
-        reply
+        return reply
       end
 
       def parse_element(reply, node)
@@ -1040,17 +983,16 @@ module ActiveMerchant # :nodoc:
         else
           if node.parent.name =~ /item/
             parent = node.parent.name
-            parent += "_#{node.parent.attributes['id']}" if node.parent.attributes['id']
+            parent += '_' + node.parent.attributes['id'] if node.parent.attributes['id']
             parent += '_'
           end
           reply["#{parent}#{node.name}".to_sym] ||= node.text
         end
-        reply
+        return reply
       end
 
       def reason_message(reason_code)
         return if reason_code.blank?
-
         @@response_codes[:"r#{reason_code}"]
       end
 

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -788,8 +788,6 @@ module ActiveMerchant #:nodoc:
           sign_and_add_signature_value(doc, signature_element, sign_info)
           add_key_information(doc, signature_element)
           doc.to_xml
-        elsif @options[:p12].blank? ^ @options[:p12_password].blank?
-          raise ArgumentError, "Both p12 certificate contents ('@options[:p12]')and its password (''@options[:p12]'') must be provided together, or neither should be present."
         else
           xml.target!
         end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -937,7 +937,7 @@ module ActiveMerchant #:nodoc:
         rescue REXML::ParseException => e
           response = { message: e.to_s }
         end
-        binding.pry
+
         success = response[:decision] == 'ACCEPT'
 
         response_code = ('r' + response.fetch(:reasonCode,'')).to_sym

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -844,10 +844,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def generate_security_token(doc)
-        cert = OpenSSL::PKCS12.new(@options[:p12], @options[:p12_password])
+        decoded_p12_cert =  Base64.decode64(@options[:p12])
+        cert = OpenSSL::PKCS12.new(decoded_p12_cert, @options[:p12_password])
         @private_key = cert.key
-        p12 = OpenSSL::PKCS12.new(@options[:p12], @options[:p12_password])
-        certificate = p12.certificate.to_pem
+        certificate = cert.certificate.to_pem
 
         pubcert_lines = certificate.lines.map(&:strip) # Split and trim each line
         pubcert_lines.shift # Remove "-----BEGIN CERTIFICATE-----"

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -779,13 +779,6 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
-        opts_copy = @options.dup
-        p12_cert_100_first_chars = opts_copy[:p12_certificate].to_s[0..100]
-        p12_pass_5_first_chars = opts_copy[:p12_certificate_password].to_s[0..5]
-        opts_copy[:p12_certificate] = p12_cert_100_first_chars + '...' if opts_copy[:p12_certificate].present?
-        opts_copy[:p12_certificate_password] = p12_pass_5_first_chars + '...' if opts_copy[:p12_certificate_password].present?
-        will_use_new_flow = @options[:p12_certificate].present? && @options[:p12_certificate_password].present?
-        Honeybadger.notify("Auth flow check", context: {'options' => @options, 'will_use_new_flow': will_use_new_flow})
         if @options[:p12_certificate].present? && @options[:p12_certificate_password].present?
           doc = parse_xml(xml)
           security_element = initialize_security_element(doc)

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -779,6 +779,13 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
+        opts_copy = @options.dup
+        p12_cert_100_first_chars = opts_copy[:p12_certificate].to_s[0..100]
+        p12_pass_5_first_chars = opts_copy[:p12_certificate_password].to_s[0..5]
+        opts_copy[:p12_certificate] = p12_cert_100_first_chars + '...' if opts_copy[:p12_certificate].present?
+        opts_copy[:p12_certificate_password] = p12_pass_5_first_chars + '...' if opts_copy[:p12_certificate_password].present?
+        will_use_new_flow = @options[:p12_certificate].present? && @options[:p12_certificate_password].present?
+        Honeybadger.notify("Auth flow check", context: {'options' => @options, 'will_use_new_flow': will_use_new_flow})
         if @options[:p12_certificate].present? && @options[:p12_certificate_password].present?
           doc = parse_xml(xml)
           security_element = initialize_security_element(doc)
@@ -930,7 +937,7 @@ module ActiveMerchant #:nodoc:
         rescue REXML::ParseException => e
           response = { message: e.to_s }
         end
-
+        binding.pry
         success = response[:decision] == 'ACCEPT'
 
         response_code = ('r' + response.fetch(:reasonCode,'')).to_sym

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -102,9 +102,9 @@ module ActiveMerchant #:nodoc:
       #
       # :password =>  the transaction key you generated in the Business Center
       #
-      # :p12 => the contents of your .p12 file
+      # :p12_certificate => the contents of your .p12 file
       #
-      # :p12_password => the password you set on your .p12 file
+      # :p12_certificate_password => the password you set on your .p12 file
       #
       # :test => true   sets the gateway to test mode
       #
@@ -119,7 +119,7 @@ module ActiveMerchant #:nodoc:
       # :ignore_cvv => true   don't want to use CVV so continue processing even
       #                       if CVV would have failed
       def initialize(options = {})
-        requires!(options, :login, :password, :p12, :p12_password)
+        requires!(options, :login, :password, :p12_certificate, :p12_certificate_password)
         super
       end
 
@@ -779,7 +779,7 @@ module ActiveMerchant #:nodoc:
             end
           end
         end
-        if @options[:p12].present? && @options[:p12_password].present?
+        if @options[:p12_certificate].present? && @options[:p12_certificate_password].present?
           doc = parse_xml(xml)
           security_element = initialize_security_element(doc)
           add_security_token(doc, security_element)
@@ -842,8 +842,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def generate_security_token(doc)
-        decoded_p12_cert =  Base64.decode64(@options[:p12])
-        cert = OpenSSL::PKCS12.new(decoded_p12_cert, @options[:p12_password])
+        decoded_p12_cert =  Base64.decode64(@options[:p12_certificate])
+        cert = OpenSSL::PKCS12.new(decoded_p12_cert, @options[:p12_certificate_password])
         @private_key = cert.key
         certificate = cert.certificate.to_pem
 

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "cybersource-test"
+  VERSION = "1.61.0"
 end

--- a/lib/active_merchant/version.rb
+++ b/lib/active_merchant/version.rb
@@ -1,3 +1,3 @@
 module ActiveMerchant
-  VERSION = "1.60.0"
+  VERSION = "cybersource-test"
 end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -249,8 +249,8 @@ culqi:
 cyber_source:
   login: X
   password: Y
-  p12: ''
-  p12_password: ''
+  p12_certificate: ''
+  p12_certificate_password: ''
 
 # Working credentials, no need to replace
 d_local:

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -248,7 +248,7 @@ culqi:
 # services on your test account.
 cyber_source:
   login: X
-  password:
+  password: Y
   p12: ''
   p12_password: ''
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -248,7 +248,9 @@ culqi:
 # services on your test account.
 cyber_source:
   login: X
-  password: Y
+  password:
+  p12: ''
+  p12_password: ''
 
 # Working credentials, no need to replace
 d_local:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -287,7 +287,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.load(File.read(file_name))
+          yaml_data = YAML.load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -9,7 +9,9 @@ class CyberSourceTest < Test::Unit::TestCase
 
     @gateway = CyberSourceGateway.new(
       :login => 'l',
-      :password => 'p'
+      :password => 'p',
+      :p12 => '',
+      :p12_password => ''
     )
 
     @amount = 100

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -10,8 +10,8 @@ class CyberSourceTest < Test::Unit::TestCase
     @gateway = CyberSourceGateway.new(
       :login => 'l',
       :password => 'p',
-      :p12 => '',
-      :p12_password => ''
+      :p12_certificate => '',
+      :p12_certificate_password => ''
     )
 
     @amount = 100


### PR DESCRIPTION
Ticket:
https://maxioevolution.atlassian.net/browse/PAYM-1989

What
- We need to handle the new auth flow using a p12 certificate when using the Cybersource gateway. We must keep the old flow too.

Why
- Cybersource is changing their auth method to using a p12 certificate to sign every request based on its payload, so we need to add this

How
- The gateway initializer can now receive 2 new attributes: `p_12` (the certificate contents) and `p12_password` (the password to decrypt it)
- A new flow is added when creating the payload to be sent to the SOAP API
- The Cybersource gateway class now supports login and password auth and the new p12 cert auth flow.
- This implementation mimics Cybersource's [official PHP toolkit](https://github.com/CyberSource/cybersource-soap-toolkit/blob/master/PHPSoapToolkit/ExtendedClientWithToken.php)