### PR TITLE
[Internal] add rexml as a dependency

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('square.rb', '~> 16.0')
   s.add_dependency('jwt')
-  s.add_dependency('rexml', '3.2.5')
+  s.add_dependency('rexml', '3.2.6')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('square.rb', '~> 16.0')
   s.add_dependency('jwt')
-  s.add_dependency('rexml', '~> 3.4.1')
+  s.add_dependency('rexml', '~> 3.2.5')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('square.rb', '~> 16.0')
   s.add_dependency('jwt')
-  s.add_dependency('rexml', '~> 3.2.5')
+  s.add_dependency('rexml', '3.2.5')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')

--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('nokogiri', "~> 1.4")
   s.add_dependency('square.rb', '~> 16.0')
   s.add_dependency('jwt')
+  s.add_dependency('rexml', '~> 3.4.1')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')


### PR DESCRIPTION
Ticket:
[PAY-2151](https://maxioevolution.atlassian.net/browse/PAY-2151)

What
We need to mode the `rexml` dependency from `Payments` to this fork.

Why
To decrease the dependencies on our apps

How
Adding the dependency to this project and move it from `Payments` and `Chargify`

### Code review tips
- The dependencies were updated in `Chargify`, `Payments` and `ActiveMerchant`.
  - Payments: https://github.com/maxio-com/payments/pull/303
  - ActiveMerchant: https://github.com/maxio-com/active_merchant/pull/238
  - Chargify: https://github.com/maxio-com/chargify/pull/25507

[PAY-2151]: https://maxioevolution.atlassian.net/browse/PAY-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ