### PR TITLE
[internal] Bump Braintree gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gem 'jruby-openssl', :platforms => :jruby
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec
-  gem 'braintree', '>= 2.50.0'
+  gem 'braintree', '>= 4.23.0'
 end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -6,8 +6,8 @@ rescue LoadError
   raise "Could not load the braintree gem.  Use `gem install braintree` to install it."
 end
 
-unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 78
-  raise "Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version."
+unless Braintree::Version::Major == 4 && Braintree::Version::Minor >= 23
+  raise "Need braintree gem >= 4.23.0. Run `gem install braintree --version '~>4.23'` to get the correct version."
 end
 
 module ActiveMerchant #:nodoc:


### PR DESCRIPTION
Ticket: https://maxioevolution.atlassian.net/browse/PAY-2069

### WHAT?
Bump braintree gem version

### WHY?
From June 30, 2025 previous version won't be compatible with their API

### Related PRs:
https://github.com/maxio-com/conduit/pull/443
https://github.com/maxio-com/chargify/pull/25884